### PR TITLE
Re-enable static tests over generated image

### DIFF
--- a/.github/test/docker-compose.yml
+++ b/.github/test/docker-compose.yml
@@ -10,13 +10,13 @@ services:
     restart: unless-stopped
 
   lms:
-    image: eoluchile/edx-platform:testing-koa
+    image: ghcr.io/eol-uchile/edx-platform:testing-koa
     depends_on:
       - memcached
       - mongodb
   
   cms:
-    image: eoluchile/edx-platform:testing-koa
+    image: ghcr.io/eol-uchile/edx-platform:testing-koa
     depends_on:
       - memcached
       - mongodb

--- a/.github/test/tests.sh
+++ b/.github/test/tests.sh
@@ -7,8 +7,15 @@ cd /openedx/edx-platform
 mkdir -p test_root/log/
 
 # Install required edx-ora2 for tests
-#pip3 install -e git+https://github.com/fdns/edx-ora2.git@810e75fb2028272c10b3b86b645720c3e584a4c6#egg=ora2
 pip3 install ora2==2.11.5.1
 
-# Test given parameter
-DJANGO_SETTINGS_MODULE=lms.envs.test EDXAPP_TEST_MONGO_HOST=mongodb pytest $1
+# Test EOL Modifications
+
+# Task Helper modifications for uchileedxlogin package
+## Test before installing the package
+DJANGO_SETTINGS_MODULE=lms.envs.test EDXAPP_TEST_MONGO_HOST=mongodb pytest \
+	lms/djangoapps/instructor_task/tests/test_tasks_helper.py \
+	lms/djangoapps/instructor_analytics/tests/test_basic.py \
+	lms/djangoapps/certificates/tests/test_webview_views.py \
+	lms/djangoapps/bulk_email/tests/ \
+	lms/djangoapps/instructor/tests/

--- a/.github/test/tests.sh
+++ b/.github/test/tests.sh
@@ -13,7 +13,7 @@ pip3 install ora2==2.11.5.1
 
 # Task Helper modifications for uchileedxlogin package
 ## Test before installing the package
-DJANGO_SETTINGS_MODULE=lms.envs.test EDXAPP_TEST_MONGO_HOST=mongodb pytest \
+DJANGO_SETTINGS_MODULE=lms.envs.test EDXAPP_TEST_MONGO_HOST=mongodb pytest --exitfirst --full-trace --verbose \
 	lms/djangoapps/instructor_task/tests/test_tasks_helper.py \
 	lms/djangoapps/instructor_analytics/tests/test_basic.py \
 	lms/djangoapps/certificates/tests/test_webview_views.py \

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,12 +65,7 @@ jobs:
       - name: Test eol changes
         run: |
           cd .github/test
-          docker-compose run lms /openedx/edx-platform/.github/test/tests.sh lms/djangoapps/instructor_task/tests/test_tasks_helper.py && docker-compose down -v
-          docker-compose run lms /openedx/edx-platform/.github/test/tests.sh lms/djangoapps/instructor_analytics/tests/test_basic.py  && docker-compose down -v
-          docker-compose run lms /openedx/edx-platform/.github/test/tests.sh lms/djangoapps/certificates/tests/test_webview_views.py && docker-compose down -v
-          docker-compose run lms /openedx/edx-platform/.github/test/tests.sh lms/djangoapps/bulk_email/tests/ && docker-compose down -v
-          docker-compose run lms /openedx/edx-platform/.github/test/tests.sh lms/djangoapps/instructor/tests/ && docker-compose down -v
-          docker-compose run cms /openedx/edx-platform/.github/test/tests_cms.sh cms/djangoapps/contentstore/views/tests/test_videos.py && docker-compose down -v
+          docker-compose run lms /openedx/edx-platform/.github/test/tests.sh
 
       - name: Login to GitHub Container Registry
         if: startsWith(github.ref, 'refs/heads/eol-release/')

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -63,12 +63,7 @@ jobs:
       - name: Test eol changes
         run: |
           cd .github/test
-          docker-compose run lms /openedx/edx-platform/.github/test/tests.sh lms/djangoapps/instructor_task/tests/test_tasks_helper.py && docker-compose down -v
-          docker-compose run lms /openedx/edx-platform/.github/test/tests.sh lms/djangoapps/instructor_analytics/tests/test_basic.py  && docker-compose down -v
-          docker-compose run lms /openedx/edx-platform/.github/test/tests.sh lms/djangoapps/certificates/tests/test_webview_views.py && docker-compose down -v
-          docker-compose run lms /openedx/edx-platform/.github/test/tests.sh lms/djangoapps/bulk_email/tests/ && docker-compose down -v
-          docker-compose run lms /openedx/edx-platform/.github/test/tests.sh lms/djangoapps/instructor/tests/ && docker-compose down -v
-          docker-compose run cms /openedx/edx-platform/.github/test/tests_cms.sh cms/djangoapps/contentstore/views/tests/test_videos.py && docker-compose down -v
+          docker-compose run lms /openedx/edx-platform/.github/test/tests.sh
 
       - name: Login to GitHub Container Registry
         if: startsWith(github.ref, 'refs/heads/eol/')

--- a/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
+++ b/lms/djangoapps/instructor/tests/test_spoc_gradebook.py
@@ -64,7 +64,7 @@ class TestGradebook(SharedModuleStoreTestCase):
         self.users = [UserFactory.create() for _ in range(USER_COUNT)]
 
         for user in self.users:
-            CourseEnrollmentFactory.create(user=user, course_id=self.course.id)
+            CourseEnrollmentFactory.create(user=user, course_id=self.course.id, mode="honor")
 
         for i, item in enumerate(self.items):
             for j, user in enumerate(self.users):

--- a/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
+++ b/lms/djangoapps/instructor/tests/views/test_instructor_dashboard.py
@@ -560,7 +560,7 @@ class TestInstructorDashboard(ModuleStoreTestCase, LoginEnrollmentTestCase, XssT
         for i in range(2):
             username = "user_%d" % i
             student = UserFactory.create(username=username)
-            CourseEnrollmentFactory.create(user=student, course_id=self.course.id)
+            CourseEnrollmentFactory.create(user=student, course_id=self.course.id, mode="honor")
         url = reverse(
             'spoc_gradebook',
             kwargs={'course_id': self.course.id}
@@ -652,7 +652,7 @@ class TestInstructorDashboardPerformance(ModuleStoreTestCase, LoginEnrollmentTes
         for i in range(20):
             username = "user_%d" % i
             student = UserFactory.create(username=username)
-            CourseEnrollmentFactory.create(user=student, course_id=self.course.id)
+            CourseEnrollmentFactory.create(user=student, course_id=self.course.id, mode="honor")
             students.append(student)
 
         chapter = ItemFactory.create(

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -2643,7 +2643,7 @@ class TestInstructorOra2Report(SharedModuleStoreTestCase):
             course_id_string = quote(text_type(self.course.id).replace('/', '_'))
             filename = u'{}_ORA_data_{}.csv'.format(course_id_string, timestamp_str)
 
-            self.assertEqual(return_val, UPDATE_STATUS_SUCCEEDED)
+            self.assertDictContainsSubset({'attempted': 1, 'succeeded': 1, 'failed': 0}, return_val)
             mock_store_rows.assert_called_once_with(self.course.id, filename, [test_header] + test_rows)
 
 


### PR DESCRIPTION
Re-enable static tests
 - Pointing tests over local generated image.
 - Revert change for run tests separately.
 - Config tests to stop at first error and enhanced verbosity.
 - Fix tests complementing commits 9e410d4ab0c8d9108382759d1cdf23b948c02fc0 and 797ab6e3d8f27e53bfbc537a14d44504fbe9ee44.