### PR TITLE
(EOL) Jjorgeb/update uchileedxlogin dependencies

### DIFF
--- a/lms/djangoapps/instructor_analytics/basic.py
+++ b/lms/djangoapps/instructor_analytics/basic.py
@@ -19,6 +19,7 @@ from django.urls import reverse
 from edx_proctoring.api import get_exam_violation_report
 from opaque_keys.edx.keys import CourseKey, UsageKey
 from six import text_type
+from uchileedxlogin.services.interface import get_user_id_doc_id_pairs
 
 import xmodule.graders as xmgraders
 from lms.djangoapps.courseware.models import StudentModule
@@ -113,7 +114,9 @@ def enrolled_students_features(course_key, features):
 
     ####### EOL ###############
     if include_run_column and settings.UCHILEEDXLOGIN_TASK_RUN_ENABLE:
-        students = students.prefetch_related('edxloginuser')
+        user_id_list = students.values_list('id', flat=True)
+        user_doc_id = get_user_id_doc_id_pairs(user_id_list)
+        user_doc_id_dict = {id: doc_id for id, doc_id in user_doc_id}
 
     def extract_attr(student, feature):
         """Evaluate a student attribute that is ready for JSON serialization"""
@@ -141,11 +144,7 @@ def enrolled_students_features(course_key, features):
         student_dict = {}
         ########### EOL ##########################
         if settings.UCHILEEDXLOGIN_TASK_RUN_ENABLE:
-            try:
-                from uchileedxlogin.models import EdxLoginUser
-                student_dict['run'] = student.edxloginuser.run
-            except EdxLoginUser.DoesNotExist:
-                student_dict['run'] = ""
+            student_dict['run'] = user_doc_id_dict.get(student['id'], '')
         ###########################################
         student_dict_aux = dict((feature, extract_attr(student, feature))
                             for feature in student_features)

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -290,7 +290,7 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
     ################ EOL ###############################################
     @patch('lms.djangoapps.instructor_analytics.basic.get_user_id_doc_id_pairs')
     @override_settings(UCHILEEDXLOGIN_TASK_RUN_ENABLE=True)
-    def test_enrolled_students_features_keys_with_run(self, mock_user_id_doc_id_pairs):
+    def test_enrolled_students_features_keys_with_doc_id(self, mock_user_id_doc_id_pairs):
         user_id_doc_id_pairs_list = []
         runs = ('run',)
         query_features = ('run', 'username', 'name', 'email', 'city', 'country',)

--- a/lms/djangoapps/instructor_analytics/tests/test_basic.py
+++ b/lms/djangoapps/instructor_analytics/tests/test_basic.py
@@ -288,20 +288,18 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
             self.assertEqual(set(proctored_exam_attempt.keys()), set(query_features))
 
     ################ EOL ###############################################
+    @patch('lms.djangoapps.instructor_analytics.basic.get_user_id_doc_id_pairs')
     @override_settings(UCHILEEDXLOGIN_TASK_RUN_ENABLE=True)
-    def test_enrolled_students_features_keys_with_run(self):
-        try:
-            from unittest.case import SkipTest
-            from uchileedxlogin.models import EdxLoginUser
-        except ImportError:
-            self.skipTest("import error uchileedxlogin")
+    def test_enrolled_students_features_keys_with_run(self, mock_user_id_doc_id_pairs):
+        user_id_doc_id_pairs_list = []
         runs = ('run',)
         query_features = ('run', 'username', 'name', 'email', 'city', 'country',)
         for user in self.users:
-            EdxLoginUser.objects.create(user=user, run='000000000{}'.format(user.id))
+            user_id_doc_id_pairs_list.return_value.append((user.id,'000000000{}'.format(user.id)))
             user.profile.city = "Mos Eisley {}".format(user.id)
             user.profile.country = "Tatooine {}".format(user.id)
             user.profile.save()
+        mock_user_id_doc_id_pairs.return_value = user_id_doc_id_pairs_list
         for feature in query_features:
             self.assertIn(feature, AVAILABLE_FEATURES + runs)
         with self.assertNumQueries(2):
@@ -311,11 +309,10 @@ class TestAnalyticsBasic(ModuleStoreTestCase):
         userreports = sorted(userreports, key=lambda u: u["username"])
         users = sorted(self.users, key=lambda u: u.username)
         for userreport, user in zip(userreports, users):
-            aux = EdxLoginUser.objects.get(user=user)
             self.assertEqual(set(userreport.keys()), set(query_features))
             self.assertEqual(userreport['username'], user.username)
             self.assertEqual(userreport['email'], user.email)
             self.assertEqual(userreport['name'], user.profile.name)
             self.assertEqual(userreport['city'], user.profile.city)
             self.assertEqual(userreport['country'], user.profile.country)
-            self.assertEqual(userreport['run'], aux.run)        
+            self.assertEqual(userreport['run'], '000000000{}'.format(user.id))        

--- a/lms/djangoapps/instructor_task/tasks_helper/grades.py
+++ b/lms/djangoapps/instructor_task/tasks_helper/grades.py
@@ -18,6 +18,7 @@ from opaque_keys.edx.keys import UsageKey
 from pytz import UTC
 from six import text_type
 from six.moves import zip, zip_longest
+from uchileedxlogin.services.interface import get_user_id_doc_id_pairs
 
 from common.djangoapps.course_modes.models import CourseMode
 from lms.djangoapps.certificates.models import CertificateWhitelist, GeneratedCertificate, certificate_info_for_user
@@ -693,12 +694,10 @@ class CourseGradeReport(object):
         """
         Returns a list of rows for the given users for this report.
         """
-        user_runs= {}
         if settings.UCHILEEDXLOGIN_TASK_RUN_ENABLE:
-            from uchileedxlogin.models import EdxLoginUser
-            edxlogin_user = EdxLoginUser.objects.all().values('user_id','run')
-            for x in edxlogin_user:
-                user_runs[x['user_id']] = x['run']
+            user_id_list = users.values_list('id', flat=True)
+            user_doc_id = get_user_id_doc_id_pairs(user_id_list)
+            user_doc_id_dict = {id: doc_id for id, doc_id in user_doc_id}
 
         with modulestore().bulk_operations(context.course_id):
             bulk_context = _CourseGradeBulkContext(context, users)
@@ -717,10 +716,8 @@ class CourseGradeReport(object):
                     aux = [user.id, user.email, user.username]
                     ########### EOL ##########################
                     if settings.UCHILEEDXLOGIN_TASK_RUN_ENABLE:
-                        if user.id in user_runs:
-                            aux = [user.id, user_runs[user.id], user.email, user.username]
-                        else:
-                            aux = [user.id, "", user.email, user.username]
+                        user_doc_id = user_doc_id_dict.get(user['id'], '')
+                        aux = [user.id, user_doc_id, user.email, user.username]
                     ###########################################
 
                     success_rows.append(

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -1269,19 +1269,15 @@ class TestStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
         self.assertDictContainsSubset({'attempted': num_students, 'succeeded': num_students, 'failed': 0}, result)
 
     ################ EOL ###############################################
+    @patch('lms.djangoapps.instructor_analytics.basic.get_user_id_doc_id_pairs')
     @override_settings(UCHILEEDXLOGIN_TASK_RUN_ENABLE=True)
-    def test_users_with_run(self):
+    def test_users_with_run(self, mock_user_id_doc_id_pairs):
         """
         Test uchileedxlogin users
         """
-        try:
-            from unittest.case import SkipTest
-            from uchileedxlogin.models import EdxLoginUser
-        except ImportError:
-            self.skipTest("import error uchileedxlogin")
-
         aux_student = self.create_student(username="student1", email='student1@example.com')
-        EdxLoginUser.objects.create(user=aux_student, run='000000001K')
+        aux_student_doc_id = '000000001K'
+        mock_user_id_doc_id_pairs.return_value = [(aux_student.id, aux_student_doc_id)]
 
         self.current_task = Mock()
         self.current_task.update_state = Mock()
@@ -1300,7 +1296,7 @@ class TestStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
                 [
                     {
                         u'id': unicode(aux_student.id),
-                        u'run': '000000001K',
+                        u'run': aux_student_doc_id,
                         u'email': aux_student.email,
                         u'username': aux_student.username,
                     },
@@ -1840,17 +1836,13 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
                     self.assertFalse(mock_course_blocks.called)
 
     ################ EOL ###############################################
+    @patch('lms.djangoapps.instructor_task.task_helper.grades.get_user_id_doc_id_pairs')
     @override_settings(UCHILEEDXLOGIN_TASK_RUN_ENABLE=True)            
-    def test_grade_report_with_run(self):
-        try:
-            from unittest.case import SkipTest
-            from uchileedxlogin.models import EdxLoginUser
-        except ImportError:
-            self.skipTest("import error uchileedxlogin")
+    def test_grade_report_with_run(self, mock_user_id_doc_id_pairs):
             
         self.submit_student_answer(self.student.username, u'Problem1', ['Option 1'])  
 
-        EdxLoginUser.objects.create(user=self.student, run='009472337K')
+        mock_user_id_doc_id_pairs.return_value = [(self.student.id, '009472337K')]
         with patch('lms.djangoapps.instructor_task.tasks_helper.runner._get_current_task'):
             result = CourseGradeReport.generate(None, None, self.course.id, None, 'graded')
 

--- a/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
+++ b/lms/djangoapps/instructor_task/tests/test_tasks_helper.py
@@ -1271,7 +1271,7 @@ class TestStudentReport(TestReportMixin, InstructorTaskCourseTestCase):
     ################ EOL ###############################################
     @patch('lms.djangoapps.instructor_analytics.basic.get_user_id_doc_id_pairs')
     @override_settings(UCHILEEDXLOGIN_TASK_RUN_ENABLE=True)
-    def test_users_with_run(self, mock_user_id_doc_id_pairs):
+    def test_users_with_doc_id(self, mock_user_id_doc_id_pairs):
         """
         Test uchileedxlogin users
         """
@@ -1838,7 +1838,7 @@ class TestGradeReport(TestReportMixin, InstructorTaskModuleTestCase):
     ################ EOL ###############################################
     @patch('lms.djangoapps.instructor_task.task_helper.grades.get_user_id_doc_id_pairs')
     @override_settings(UCHILEEDXLOGIN_TASK_RUN_ENABLE=True)            
-    def test_grade_report_with_run(self, mock_user_id_doc_id_pairs):
+    def test_grade_report_with_doc_id(self, mock_user_id_doc_id_pairs):
             
         self.submit_student_answer(self.student.username, u'Problem1', ['Option 1'])  
 


### PR DESCRIPTION
Se actualizan las dependencias con uchileedxlogin, para utilizar la interfaz en vez de acceder directamente a las vistas o al modelo.
Se modifican los tests para simular las respuestas de la interfaz de uchileedxlogin en vez de crear una tupla en el modelo.