### PR TITLE
ci: use GitHub App token for webhook

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -114,4 +114,3 @@ jobs:
       code: ${{ needs.variables.outputs.code }}
       release-name: ${{ needs.variables.outputs.release-name }}
       is-prod: ${{ needs.variables.outputs.is-prod }}
-    secrets: inherit

--- a/.github/workflows/webhook.yml
+++ b/.github/workflows/webhook.yml
@@ -12,9 +12,6 @@ on:
       is-prod:
         required: true
         type: string
-    secrets:
-      WEBHOOK_SECRET:
-        required: true
   repository_dispatch:
     types: [debug-webhook]
 
@@ -23,6 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.code || github.event.client_payload.debug }}
     steps:
+      - name: Create GitHub App Token
+        id: app_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.EOLITO_BOT_APP_ID }}
+          private-key: ${{ secrets.EOLITO_BOT_PRIVATE_KEY }}
+          owner: eol-uchile
+          repositories: edx-staging,eol-edx,edx-openuchile
       - name: Define release name
         id: release
         run: |
@@ -33,16 +38,16 @@ jobs:
       - name: Trigger edx-staging repository branch eol
         if: ${{ ( inputs.is-prod == 'false' && inputs.code == 'eol' ) || ( github.event.client_payload.staging && github.event.client_payload.debug == 'eol' ) }}
         run: |
-          curl --fail-with-body -X POST -H "Authorization: Bearer ${{ secrets.WEBHOOK_SECRET }}" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" https://api.github.com/repos/eol-uchile/edx-staging/dispatches --data "{\"event_type\": \"update-image\", \"client_payload\": {\"version\": \"${{ steps.release.outputs.RELEASE_NAME }}\", \"project\": \"eol\", \"code\": \"eol\"}}"
+          curl --fail-with-body -X POST -H "Authorization: Bearer ${{ steps.app_token.outputs.token }}" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" https://api.github.com/repos/eol-uchile/edx-staging/dispatches --data "{\"event_type\": \"update-image\", \"client_payload\": {\"version\": \"${{ steps.release.outputs.RELEASE_NAME }}\", \"project\": \"eol\", \"code\": \"eol\"}}"
       - name: Trigger edx-staging repository branch openuchile
         if: ${{ ( inputs.is-prod == 'false' && inputs.code == 'ou' ) || ( github.event.client_payload.staging && github.event.client_payload.debug == 'ou' ) }}
         run: |
-          curl --fail-with-body -X POST -H "Authorization: Bearer ${{ secrets.WEBHOOK_SECRET }}" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" https://api.github.com/repos/eol-uchile/edx-staging/dispatches --data "{\"event_type\": \"update-image\", \"client_payload\": {\"version\": \"${{ steps.release.outputs.RELEASE_NAME }}\", \"project\": \"openuchile\", \"code\": \"ou\"}}"
+          curl --fail-with-body -X POST -H "Authorization: Bearer ${{ steps.app_token.outputs.token }}" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" https://api.github.com/repos/eol-uchile/edx-staging/dispatches --data "{\"event_type\": \"update-image\", \"client_payload\": {\"version\": \"${{ steps.release.outputs.RELEASE_NAME }}\", \"project\": \"openuchile\", \"code\": \"ou\"}}"
       - name: Trigger edx-eol repository
         if: ${{ ( inputs.is-prod == 'true' && inputs.code == 'eol' ) || ( github.event.client_payload.production && github.event.client_payload.debug == 'eol' ) }}
         run: |
-          curl --fail-with-body -X POST -H "Authorization: Bearer ${{ secrets.WEBHOOK_SECRET }}" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" https://api.github.com/repos/eol-uchile/eol-edx/dispatches --data "{\"event_type\": \"update-image\", \"client_payload\": {\"version\": \"${{ steps.release.outputs.RELEASE_NAME }}\", \"project\": \"eol\", \"code\": \"eol\"}}"
+          curl --fail-with-body -X POST -H "Authorization: Bearer ${{ steps.app_token.outputs.token }}" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" https://api.github.com/repos/eol-uchile/eol-edx/dispatches --data "{\"event_type\": \"update-image\", \"client_payload\": {\"version\": \"${{ steps.release.outputs.RELEASE_NAME }}\", \"project\": \"eol\", \"code\": \"eol\"}}"
       - name: Trigger edx-openuchile repository
         if: ${{ ( inputs.is-prod == 'true' && inputs.code == 'ou' ) || ( github.event.client_payload.production && github.event.client_payload.debug == 'ou' ) }}
         run: |
-          curl --fail-with-body -X POST -H "Authorization: Bearer ${{ secrets.WEBHOOK_SECRET }}" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" https://api.github.com/repos/eol-uchile/edx-openuchile/dispatches --data "{\"event_type\": \"update-image\", \"client_payload\": {\"version\": \"${{ steps.release.outputs.RELEASE_NAME }}\", \"project\": \"openuchile\", \"code\": \"ou\"}}"
+          curl --fail-with-body -X POST -H "Authorization: Bearer ${{ steps.app_token.outputs.token }}" -H "Accept: application/vnd.github+json" -H "Content-Type: application/json" https://api.github.com/repos/eol-uchile/edx-openuchile/dispatches --data "{\"event_type\": \"update-image\", \"client_payload\": {\"version\": \"${{ steps.release.outputs.RELEASE_NAME }}\", \"project\": \"openuchile\", \"code\": \"ou\"}}"


### PR DESCRIPTION
- Remove any requirement for WEBHOOK_SECRET—we no longer need a personal access token.
- Insert step Create GitHub App Token using `actions/create-github-app-token@v2` 