### PR TITLE
fix: prevent production settings to overwrite static files cache prefix key value

### DIFF
--- a/cms/envs/production.py
+++ b/cms/envs/production.py
@@ -180,7 +180,7 @@ if 'loc_cache' not in CACHES:
         'LOCATION': 'edx_location_mem_cache',
     }
 
-if 'staticfiles' in CACHES:
+if 'staticfiles' in CACHES and 'KEY_PREFIX' not in CACHES['staticfiles']:
     CACHES['staticfiles']['KEY_PREFIX'] = EDX_PLATFORM_REVISION
 
 # In order to transition from local disk asset storage to S3 backed asset storage,

--- a/lms/envs/production.py
+++ b/lms/envs/production.py
@@ -204,7 +204,7 @@ if 'loc_cache' not in CACHES:
         'LOCATION': 'edx_location_mem_cache',
     }
 
-if 'staticfiles' in CACHES:
+if 'staticfiles' in CACHES and 'KEY_PREFIX' not in CACHES['staticfiles']:
     CACHES['staticfiles']['KEY_PREFIX'] = EDX_PLATFORM_REVISION
 
 # In order to transition from local disk asset storage to S3 backed asset storage,


### PR DESCRIPTION
Prevent the production settings from overwriting the value of `CACHES['staticfiles']['KEY_PREFIX']` taken from the `CONFIG_FILE` (yml).

ref: https://github.com/openedx/edx-platform/issues/37378