### PR TITLE
chore(eol): change base image

### DIFF
--- a/.github/build/Dockerfile
+++ b/.github/build/Dockerfile
@@ -57,9 +57,9 @@ ADD . /openedx/edx-platform
 # Also update boto from 2.39.0 to 2.49.0 as it has an exception on python3
 # Finally, install a compatibility layer for s3 (VIDEO_TRANSCRIPTS_SETTINGS save has an ASCII error on data)
 ENV NO_PYTHON_UNINSTALL 1
-RUN pip install pip==20.3.4 \
-  && pip install --src ../venv/src -r requirements/edx/base.txt \
-  && pip install boto==2.49.0
+RUN pip install pip==20.3.4
+RUN pip install --src ../venv/src -r requirements/edx/base.txt
+RUN pip install boto==2.49.0
 
 # Manually update pytz (Timezones)
 RUN pip install pytz --upgrade
@@ -81,8 +81,8 @@ ENV PATH /openedx/bin:${PATH}
 # the settings files.
 COPY .github/build/settings/lms/*.py ./lms/envs/prod/
 COPY .github/build/settings/cms/*.py ./cms/envs/prod/
-RUN mkdir -p /openedx/config ./lms/envs/prod ./cms/envs/prod \
-  && echo "EDX_PLATFORM_REVISION: ${EDX_PLATFORM_VERSION}" > /openedx/config/revision.yml
+RUN mkdir -p /openedx/config ./lms/envs/prod ./cms/envs/prod
+RUN echo "EDX_PLATFORM_REVISION: ${EDX_PLATFORM_VERSION}" > /openedx/config/revision.yml
 
 ENV CONFIG_ROOT /openedx/config
 ENV LMS_CFG /openedx/config/lms.yml
@@ -115,7 +115,7 @@ CMD gunicorn --name ${SERVICE_VARIANT} --workers ${WORKER_COUNT:-1} --max-reques
 FROM base AS testing
 
 # Install testing packages
-RUN grep -v -x -f /openedx/edx-platform/requirements/edx/base.txt /openedx/edx-platform/requirements/edx/development.txt > /tmp/requirements.txt \
-    && pip install -r /tmp/requirements.txt \
-    && pip install boto==2.49.0 \
-    && rm /tmp/requirements.txt
+RUN grep -v -x -f /openedx/edx-platform/requirements/edx/base.txt /openedx/edx-platform/requirements/edx/development.txt > /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+RUN pip install boto==2.49.0
+RUN rm /tmp/requirements.txt

--- a/.github/build/Dockerfile
+++ b/.github/build/Dockerfile
@@ -101,10 +101,6 @@ RUN openedx-assets xmodule \
     && openedx-assets webpack --env=prod \
     && openedx-assets common
 
-# service variant is "lms" or "cms"
-ENV SERVICE_VARIANT lms
-ENV SETTINGS prod.production
-
 # Entrypoint will fix permissions of all files and run commands as openedx
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/.github/build/Dockerfile
+++ b/.github/build/Dockerfile
@@ -89,18 +89,6 @@ ENV LMS_CFG /openedx/config/lms.yml
 ENV STUDIO_CFG /openedx/config/cms.yml
 ENV REVISION_CFG /openedx/config/revision.yml
 
-# Collect production assets. By default, only assets from the default theme
-# will be processed. This makes the docker image lighter and faster to build.
-# Only the custom themes added to /openedx/themes will be compiled.
-# Here, we don't run "paver update_assets" which is slow, compiles all themes
-# and requires a complex settings file. Instead, we decompose the commands
-# and run each one individually to collect the production static assets to
-# /openedx/staticfiles.
-RUN openedx-assets xmodule \
-    && openedx-assets npm \
-    && openedx-assets webpack --env=prod \
-    && openedx-assets common
-
 # Entrypoint will fix permissions of all files and run commands as openedx
 ENTRYPOINT ["docker-entrypoint.sh"]
 

--- a/.github/build/Dockerfile
+++ b/.github/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal as base
+FROM ubuntu:focal AS base
 
 ############ common to lms & cms
 ARG EDX_PLATFORM_VERSION=undefined
@@ -112,7 +112,7 @@ ENTRYPOINT ["docker-entrypoint.sh"]
 EXPOSE 8000
 CMD gunicorn --name ${SERVICE_VARIANT} --workers ${WORKER_COUNT:-1} --max-requests-jitter=50 --bind=0.0.0.0:8000 --max-requests=${MAX_REQUESTS:-1000} --preload ${SERVICE_VARIANT}.wsgi:application
 
-FROM base as testing
+FROM base AS testing
 
 # Install testing packages
 RUN grep -v -x -f /openedx/edx-platform/requirements/edx/base.txt /openedx/edx-platform/requirements/edx/development.txt > /tmp/requirements.txt \

--- a/.github/build/bin/openedx-assets
+++ b/.github/build/bin/openedx-assets
@@ -54,6 +54,7 @@ def main():
     collect = subparsers.add_parser('collect', help="Collect static assets to be served by webserver")
     collect.add_argument('-s', '--settings', default=os.environ.get('SETTINGS'), help="Django settings module")
     collect.add_argument('--systems', nargs='+', choices=['lms', 'cms'], default=['lms', 'cms'], help="Limit collection to lms or cms")
+    collect.add_argument('-r', '--static-root', default=DEFAULT_STATIC_ROOT)
     collect.set_defaults(func=run_collect)
 
     watch_themes = subparsers.add_parser('watch-themes', help="Watch theme assets for changes and recompile on-the-fly")
@@ -105,6 +106,8 @@ def run_themes(args):
                     assets._compile_sass(system, Path(theme_path), False, False, [])
 
 def run_collect(args):
+    os.environ['STATIC_ROOT_LMS'] = args.static_root
+    os.environ['STATIC_ROOT_CMS'] = os.path.join(args.static_root, 'studio')
     assets.collect_assets(args.systems, args.settings)
 
 def run_watch_themes(args):

--- a/requirements/edx/development.in
+++ b/requirements/edx/development.in
@@ -17,5 +17,5 @@ click                                   # Used for perf_tests utilities in modul
 django-debug-toolbar                    # A set of panels that display debug information about the current request/response
 edx-sphinx-theme                        # Documentation theme
 pywatchman                              # More efficient checking for runserver reload trigger events
-sphinxcontrib-openapi[markdown]==0.6.0  # OpenAPI (fka Swagger) spec renderer for Sphinx; pinned because 0.70 requires Python >=3.6
+sphinxcontrib-openapi                   # OpenAPI (fka Swagger) spec renderer for Sphinx
 vulture                                 # Detects possible dead/unused code, used in scripts/find-dead-code.sh

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -284,7 +284,7 @@ sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-httpdomain==1.7.0  # via sphinxcontrib-openapi
 sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-openapi[markdown]==0.6.0  # via -r requirements/edx/development.in
+sphinxcontrib-openapi  # via -r requirements/edx/development.in
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.4.1           # via -r requirements/edx/testing.txt, django, django-debug-toolbar


### PR DESCRIPTION
- Fixes the `testing` container image generation error (***Your build configuration is incomplete and previously worked by accident!***) by relaxing an old constraint in sphinxcontrib-openapi package version.
- Delegates asset collection to edx (eol flavors) to avoid automatic task duplication.
- Delegates environment definition where appropriate to downstream repos.

Esta es una copia calcada de #173 para la rama eol.