### PR TITLE
chore(openuchile/koa): re add testing img assets

### DIFF
--- a/.github/build/Dockerfile
+++ b/.github/build/Dockerfile
@@ -103,3 +103,14 @@ RUN grep -v -x -f /openedx/edx-platform/requirements/edx/base.txt /openedx/edx-p
 RUN pip install -r /tmp/requirements.txt
 RUN pip install boto==2.49.0
 RUN rm /tmp/requirements.txt
+
+# staticfiles env
+ENV STATIC_ROOT_LMS=/openedx/staticfiles/
+ENV STATIC_ROOT_CMS=/openedx/staticfiles/studio/
+ENV SETTINGS=test
+
+# Build static assets
+RUN openedx-assets xmodule
+RUN openedx-assets npm
+RUN openedx-assets webpack --env=prod
+RUN openedx-assets common

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,8 +43,10 @@ jobs:
           if [[ "${{ needs.variables.outputs.is-prod }}" = "true" ]]
           then
             echo "PREFIX=" >> $GITHUB_OUTPUT
+            echo "TARGET=base" >> $GITHUB_OUTPUT
           else
             echo "PREFIX=testing-" >> $GITHUB_OUTPUT
+            echo "TARGET=testing" >> $GITHUB_OUTPUT
           fi
 
       - uses: actions/checkout@v4
@@ -61,29 +63,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-v3-
 
-      - name: Build Open edX Base
+      - name: Build Open edX
         run: |
           docker buildx build . \
             --file .github/build/Dockerfile \
-            --target base \
-            --build-arg EDX_PLATFORM_VERSION=${{ env.RELEASE-NAME }}.${{ env.CODE }}-${{ env.TS }} \
-            --tag ghcr.io/eol-uchile/edx-platform:${GITHUB_SHA} \
-            --tag ghcr.io/eol-uchile/edx-platform:${{ env.CODE }}-${{ env.RELEASE-NAME }}-${{ env.TS }} \
-            --tag ghcr.io/eol-uchile/edx-platform:${{ env.CODE }}-${{ env.RELEASE-NAME }} \
-            --cache-from "type=local,src=/tmp/.buildx-cache" \
-            --cache-to "type=local,dest=/tmp/.buildx-cache-new" \
-            --output "type=docker,push=false"
-
-      - name: Build Open edX Testing version
-        run: |
-          docker buildx build . \
-            --file .github/build/Dockerfile \
-            --target testing \
-            --build-arg EDX_PLATFORM_VERSION=${{ env.RELEASE-NAME }}.testing-${{ env.CODE }}-${{ env.TS }} \
+            --target ${{ steps.prefix.outputs.TARGET }} \
+            --build-arg EDX_PLATFORM_VERSION=${{ env.RELEASE-NAME }}.${{ steps.prefix.outputs.PREFIX }}${{ env.CODE }}-${{ env.TS }} \
             --tag ghcr.io/eol-uchile/edx-platform:testing-current \
-            --tag ghcr.io/eol-uchile/edx-platform:testing-${GITHUB_SHA} \
-            --tag ghcr.io/eol-uchile/edx-platform:testing-${{ env.CODE }}-${{ env.RELEASE-NAME }}-${{ env.TS }} \
-            --tag ghcr.io/eol-uchile/edx-platform:testing-${{ env.CODE }}-${{ env.RELEASE-NAME }} \
+            --tag ghcr.io/eol-uchile/edx-platform:${GITHUB_SHA} \
+            --tag ghcr.io/eol-uchile/edx-platform:${{ steps.prefix.outputs.PREFIX }}${{ env.CODE }}-${{ env.RELEASE-NAME }}-${{ env.TS }} \
+            --tag ghcr.io/eol-uchile/edx-platform:${{ steps.prefix.outputs.PREFIX }}${{ env.CODE }}-${{ env.RELEASE-NAME }} \
             --cache-from "type=local,src=/tmp/.buildx-cache" \
             --cache-to "type=local,dest=/tmp/.buildx-cache-new" \
             --output "type=docker,push=false"
@@ -94,10 +83,10 @@ jobs:
           docker compose run lms /openedx/edx-platform/.github/test/tests.sh
 
       - name: Push the image to the registry
-        if: ${{ github.event_name == 'merge_group' || github.event_name == 'push' }}
+        if: ${{ github.event_name == 'merge_group' || ( github.event_name == 'push' && contains(github.ref, '-release/') ) }}
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-          docker push ghcr.io/eol-uchile/edx-platform:${{ steps.prefix.outputs.PREFIX }}${GITHUB_SHA}
+          docker push ghcr.io/eol-uchile/edx-platform:${GITHUB_SHA}
           docker push ghcr.io/eol-uchile/edx-platform:${{ steps.prefix.outputs.PREFIX }}${{ env.CODE }}-${{ env.RELEASE-NAME }}-${{ env.TS }}
           docker push ghcr.io/eol-uchile/edx-platform:${{ steps.prefix.outputs.PREFIX }}${{ env.CODE }}-${{ env.RELEASE-NAME }}
 


### PR DESCRIPTION
- Re-adds basic assets build to testing image for python apps tests.
- Simplify build images to avoid duplicate processings.

Obs: Same as #196 but for openuchile branch.