### PR TITLE
chore: backport fix infinite growth of cache when auto eviction is disabled

### DIFF
--- a/cms/devstack.yml
+++ b/cms/devstack.yml
@@ -51,7 +51,7 @@ CACHES:
         KEY_PREFIX: course_structure
         LOCATION:
         - edx.devstack.memcached:11211
-        TIMEOUT: '7200'
+        TIMEOUT: '604800'
     default:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key

--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -1889,7 +1889,7 @@ CACHES = {
         'KEY_PREFIX': 'course_structure',
         'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
         'LOCATION': ['localhost:11211'],
-        'TIMEOUT': '7200',
+        'TIMEOUT': '604800',  # 1 week
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
     },
     'celery': {

--- a/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
+++ b/common/lib/xmodule/xmodule/modulestore/split_mongo/mongo_connection.py
@@ -263,8 +263,9 @@ class CourseStructureCache(object):
             compressed_pickled_data = zlib.compress(pickled_data, 1)
             tagger.measure('compressed_size', len(compressed_pickled_data))
 
-            # Stuctures are immutable, so we set a timeout of "never"
-            self.cache.set(key, compressed_pickled_data, None)
+            # We rely on the course structure cache default timeout, which should be
+            # high by default (~ a few days).
+            self.cache.set(key, compressed_pickled_data)
 
 
 class MongoConnection(object):

--- a/lms/devstack.yml
+++ b/lms/devstack.yml
@@ -71,7 +71,7 @@ CACHES:
         KEY_PREFIX: course_structure
         LOCATION:
         - edx.devstack.memcached:11211
-        TIMEOUT: '7200'
+        TIMEOUT: '604800'
     default:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
         KEY_FUNCTION: common.djangoapps.util.memcache.safe_key

--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -807,7 +807,7 @@ CACHES = {
         'KEY_PREFIX': 'course_structure',
         'KEY_FUNCTION': 'common.djangoapps.util.memcache.safe_key',
         'LOCATION': ['localhost:11211'],
-        'TIMEOUT': '7200',
+        'TIMEOUT': '604800',  # 1 week
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
     },
     'celery': {


### PR DESCRIPTION
Contexto:
 - https://discuss.openedx.org/t/celery-tasks-stop-working-after-redis-files-become-too-large/13651
 - https://github.com/overhangio/tutor/pull/1001

EOL ya usa la limitación de memoria para redis, por lo cual el caché nunca crecerá sin límite en nuestras constelaciones, pero este cambio debiera producir un flujo más suave de eviction de caché dentro de ese contexto limitado, que permita no funcionar como se describe para las plataformas grandes (como edx-eol).