### PR TITLE
fix: require Django staff to call set_course_mode_price endpoint

### DIFF
--- a/lms/djangoapps/instructor/views/instructor_dashboard.py
+++ b/lms/djangoapps/instructor/views/instructor_dashboard.py
@@ -368,6 +368,11 @@ def set_course_mode_price(request, course_id):
     """
     set the new course price and add new entry in the CourseModesArchive Table
     """
+    if not request.user.is_staff:
+        return JsonResponse(
+            {'message': _("You do not have permission to perform this action.")},
+            status=403
+        )
     try:
         course_price = int(request.POST['course_price'])
     except ValueError:


### PR DESCRIPTION
The set_course_mode_price view had no authorization check beyond @login_required, meaning any authenticated user could POST to it and rewrite the honor-mode price for any course — a privilege escalation vulnerability.

Ideally this endpoint would be removed: it has no known callers in the UI (no templates or JS reference it), no tests, and targets the legacy 'honor' mode. However, it is publicly routed and external consumers may depend on it, so removal requires going through the DEPR process before we can act. In the meantime, this commit closes the security hole regardless of how active the endpoint is.


(cherry picked from commit 59bb6d669e4fdc24d96afb809e12119372d9e257)